### PR TITLE
Implement simple Gt serialization

### DIFF
--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -194,6 +194,16 @@ impl Fp12 {
     }
 }
 
+impl Fp12 {
+    pub fn to_bytes(self) -> [u8; 2 * 288] {
+        let mut res = [0; 2 * 288];
+        res[..288].copy_from_slice(&self.c0.to_bytes());
+        res[288..].copy_from_slice(&self.c1.to_bytes());
+
+        res
+    }
+}
+
 impl<'a, 'b> Mul<&'b Fp12> for &'a Fp12 {
     type Output = Fp12;
 

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -353,6 +353,16 @@ impl Fp2 {
     }
 }
 
+impl Fp2 {
+    pub fn to_bytes(self) -> [u8; 2 * 48] {
+        let mut res = [0; 2 * 48];
+        res[..48].copy_from_slice(&self.c0.to_bytes());
+        res[48..].copy_from_slice(&self.c1.to_bytes());
+
+        res
+    }
+}
+
 #[test]
 fn test_conditional_selection() {
     let a = Fp2 {

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -320,6 +320,16 @@ impl Fp6 {
     }
 }
 
+impl Fp6 {
+    pub fn to_bytes(self) -> [u8; 3 * 96] {
+        let mut res = [0; 3 * 96];
+        res[..96].copy_from_slice(&self.c0.to_bytes());
+        res[96..192].copy_from_slice(&self.c1.to_bytes());
+        res[192..].copy_from_slice(&self.c2.to_bytes());
+        res
+    }
+}
+
 impl<'a, 'b> Mul<&'b Fp6> for &'a Fp6 {
     type Output = Fp6;
 

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -254,6 +254,16 @@ impl Gt {
     }
 }
 
+impl Gt {
+    /// Serialize this element to an arbitrary unique bytestring
+    ///
+    /// No meaning should be ascribed to these bytes; they serve
+    /// only to identify this group element.
+    pub fn to_bytes(self) -> [u8; 576] {
+        self.0.to_bytes()
+    }
+}
+
 impl<'a> Neg for &'a Gt {
     type Output = Gt;
 


### PR DESCRIPTION
This only supports creating a bytestring which suffices to uniquely identify the group element. Neither compression nor deserialization are supported.