### PR TITLE
Bump crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/dfinity/bls12_381"
 license = "MIT/Apache-2.0"
 name = "ic_bls12_381"
 repository = "https://github.com/dfinity/bls12_381"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This will allow us to release a new version that includes Gt zeroize support.