### PR TITLE
Bump crate version to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/dfinity/bls12_381"
 license = "MIT/Apache-2.0"
 name = "ic_bls12_381"
 repository = "https://github.com/dfinity/bls12_381"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,12 @@
 # Unreleased
 
+# ic_bls12_381 0.10
+## Changed
+- Update sha2/sha3/digest dependencies from 0.9 to 0.10
+
 # ic_bls12_381 0.9.2
 ## Changed
+- Yanked
 - Update sha2/sha3/digest dependencies from 0.9 to 0.10
 
 # ic_bls12_381 0.9.1


### PR DESCRIPTION
The bump of `sha2` without bumping the minor number of this crate is causing problems for SDK team